### PR TITLE
Fix module loading for api-notebook browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-typesystem",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "main": "dist/src/index.js",
   "scripts": {
     "test-cov": " ./node_modules/.bin/istanbul cover _mocha dist/tests/*Tests.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-typesystem",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "main": "dist/src/index.js",
   "scripts": {
     "test-cov": " ./node_modules/.bin/istanbul cover _mocha dist/tests/*Tests.js",
@@ -19,6 +19,10 @@
     "xml2js": "^0.4.16",
     "date-and-time": "0.3.0",
     "xmldom": "^0.1.22"
+  },
+  "optionalDependencies": {
+    "raml-xml-validation": "0.0.5",
+    "raml-json-validation": "0.0.6"
   },
   "browser": {
     "raml-json-validation": false,

--- a/src/jsonUtil.ts
+++ b/src/jsonUtil.ts
@@ -8,7 +8,9 @@ var JSONValidatorConstructor: any;
 
 try {
     JSONValidatorConstructor = require("raml-json-validation").JSONValidator;
-} catch(exception) {
+} catch(exception) { }
+
+if (!JSONValidatorConstructor) {
     class JSONValidatorDummyImpl {
         setRemoteReference(reference: string, content: any): void {
             

--- a/src/xmlUtil.ts
+++ b/src/xmlUtil.ts
@@ -8,7 +8,9 @@ var XMLValidatorConstructor: any;
 
 try {
     XMLValidatorConstructor = require("raml-xml-validation").XMLValidator;
-} catch(exception) {
+} catch(exception) { }
+
+if (!XMLValidatorConstructor) {
     class XMLValidatorDummyImpl {
         constructor(arg: string) {
 

--- a/workspace.json
+++ b/workspace.json
@@ -3,7 +3,6 @@
     "build" : "npm run build",
     "test" : "gulp test",
     "gitUrl" : "https://github.com/raml-org/raml-js-parser-2.git",
-    "gitBranch": "develop",
     "installTypings" : true
   },
   "raml-definition-system" : {
@@ -26,7 +25,6 @@
   "raml-json-validation" : {
     "build" : "npm run build",
     "gitUrl" : "https://github.com/dreamflyer/raml-json-validation.git",
-    "gitBranch" : false,
     "installTypings" : true
   },
   "ts-structure-parser" : {

--- a/workspace.json
+++ b/workspace.json
@@ -8,7 +8,6 @@
   "raml-definition-system" : {
     "build" : "npm run build",
     "gitUrl" : "https://github.com/raml-org/raml-definition-system.git",
-    "gitBranch": "develop",
     "installTypings" : true
   },
   "raml-typesystem" : {
@@ -31,7 +30,6 @@
   "ts-structure-parser" : {
     "build" : "npm run build",
     "gitUrl" : "https://github.com/mulesoft-labs/ts-structure-parser.git",
-    "gitBranch": "develop",
     "installTypings" : true
   },
   "yaml-ast-parser" : {


### PR DESCRIPTION
This PR is to support the case that `require("raml-json-validation")` returns an empty object `{}`.