### PR TITLE
Fix module loading for api-notebook browserify

### DIFF
--- a/src/jsonUtil.ts
+++ b/src/jsonUtil.ts
@@ -8,7 +8,9 @@ var JSONValidatorConstructor: any;
 
 try {
     JSONValidatorConstructor = require("raml-json-validation").JSONValidator;
-} catch(exception) {
+} catch(exception) { }
+
+if (!JSONValidatorConstructor) {
     class JSONValidatorDummyImpl {
         setRemoteReference(reference: string, content: any): void {
             

--- a/src/xmlUtil.ts
+++ b/src/xmlUtil.ts
@@ -8,7 +8,9 @@ var XMLValidatorConstructor: any;
 
 try {
     XMLValidatorConstructor = require("raml-xml-validation").XMLValidator;
-} catch(exception) {
+} catch(exception) { }
+
+if (!XMLValidatorConstructor) {
     class XMLValidatorDummyImpl {
         constructor(arg: string) {
 


### PR DESCRIPTION
This is to support the case where `require("raml-json-validation")` returns an empty object `{}`.