### PR TITLE
require errorMessages.json with extension

### DIFF
--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -3,7 +3,7 @@ import _=require("underscore")
 import su=require("./schemaUtil")
 import tsInterfaces = require("./typesystem-interfaces")
 
-export let messageRegistry = require("../../resources/errorMessages");
+export let messageRegistry = require("../../resources/errorMessages.json");
 
 export type IValidationPath = tsInterfaces.IValidationPath;
 


### PR DESCRIPTION
provide ability to use library in enviroments, where .json files can't be imported without extension

fix #99 